### PR TITLE
Workflows: run CI on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+     types:
+       - opened
+       - reopened
+       - synchronize
 
 jobs:
   flatpak:


### PR DESCRIPTION
CI should run on pull request, not pushes to main