### PR TITLE
MainWindow: fix flat operations_button

### DIFF
--- a/src/Frontend/MainWindow.vala
+++ b/src/Frontend/MainWindow.vala
@@ -72,11 +72,10 @@ class Taxi.MainWindow : Gtk.ApplicationWindow {
         var popover = new OperationsPopover ();
 
         var operations_button = new Gtk.MenuButton () {
-            popover = popover,
-            valign = CENTER,
-            child = spinner
+            child = spinner,
+            has_frame = false,
+            popover = popover
         };
-        operations_button.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         spinner_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT,


### PR DESCRIPTION
Can't use flat on menubutton in Gtk4 because the actual button is a child. Use `has_frame` property instead. Also get rid of `valign = CENTER` because that makes the click target really small